### PR TITLE
Attempt to correct issue with double locations

### DIFF
--- a/PPPLib/include/PPPLib/Configuration/EvaluationConfiguration.h
+++ b/PPPLib/include/PPPLib/Configuration/EvaluationConfiguration.h
@@ -58,11 +58,8 @@ namespace Configuration
 
         /** This goes through the settings for the fit-windows to test that the settings
             make sense.
-            @return 0 if all is ok
-            @return 1 if no fit-window is defined for this spectrometer
-            @return 2 if at least one fit-window has an in-valid time range (e.g. start>stop)
-            @return 3 if there are two fit-windows with overlapping definition time */
-        int CheckSettings() const;
+            @throw std::invalid_argument with an error message if the settings are not valid */
+        void CheckSettings() const;
 
     private:
 

--- a/PPPLib/include/PPPLib/Configuration/LocationConfiguration.h
+++ b/PPPLib/include/PPPLib/Configuration/LocationConfiguration.h
@@ -31,11 +31,8 @@ namespace Configuration
 
         /** This goes through the settings for the locations to test that the settings
             make sense.
-            @return 0 if all is ok
-            @return 1 if no locations is defined for this spectrometer
-            @return 2 if at least one locations has an in-valid time range (e.g. start>stop)
-            @return 3 if there are two locations with overlapping definition time */
-        int CheckSettings() const;
+            @throw std::invalid_argument with an error message if the settings are not valid */
+        void CheckSettings() const;
 
     private:
 
@@ -43,7 +40,7 @@ namespace Configuration
         static const int MAX_N_LOCATIONS = 32;
 
         /** The number of locations that are defined for this instrument */
-        int m_locationNum;
+        int m_locationNum = 0;
 
         /** Array holding the locations that are configured for this
             instrument. Each of these also contains the time-frame

--- a/PPPLib/src/File/SetupFileReader.cpp
+++ b/PPPLib/src/File/SetupFileReader.cpp
@@ -78,6 +78,7 @@ void CSetupFileReader::Parse_Instrument(Configuration::CInstrumentConfiguration&
 
 // Parse for location area and store in the LocationConfiguration object
 void CSetupFileReader::Parse_Location(Configuration::CLocationConfiguration& loc) {
+
     Configuration::CInstrumentLocation location;
 
     // parse the file, one line at a time.
@@ -90,7 +91,7 @@ void CSetupFileReader::Parse_Location(Configuration::CLocationConfiguration& loc
         if (szToken == nullptr || strlen(szToken) < 3)
             continue;
 
-        if (novac::Equals(szToken, "/location", 8)) {
+        if (novac::Equals(szToken, "/location", 9)) {
             // insert the information that we have into the array and return.
             loc.InsertLocation(location);
             return;

--- a/PPPTests/src/UnitTest_CString.cpp
+++ b/PPPTests/src/UnitTest_CString.cpp
@@ -65,8 +65,8 @@ namespace novac
             CString apa{ "apa" };
             CString banan{ "banan" };
 
-            REQUIRE(1 == banan.Compare(apa));
-            REQUIRE(-1 == apa.Compare(banan));
+            REQUIRE(banan.Compare(apa) > 0);
+            REQUIRE(apa.Compare(banan) < 0);
         }
     }
 

--- a/PPPTests/src/UnitTest_CString.cpp
+++ b/PPPTests/src/UnitTest_CString.cpp
@@ -65,8 +65,8 @@ namespace novac
             CString apa{ "apa" };
             CString banan{ "banan" };
 
-            REQUIRE(1 == banan.Compare(apa));
-            REQUIRE(-1 == apa.Compare(banan));
+            REQUIRE(0 < banan.Compare(apa));
+            REQUIRE(0 > apa.Compare(banan));
         }
     }
 

--- a/PPPTests/src/UnitTest_EvaluationConfigurationParser.cpp
+++ b/PPPTests/src/UnitTest_EvaluationConfigurationParser.cpp
@@ -94,6 +94,8 @@ namespace novac
 
         }
 
+        REQUIRE_NOTHROW(resultingEvaluationSettings.CheckSettings());
+
         // Expected first evaluation fit window
         {
             novac::CFitWindow window;

--- a/PPPTests/src/UnitTest_ProcessingFileReader.cpp
+++ b/PPPTests/src/UnitTest_ProcessingFileReader.cpp
@@ -34,8 +34,12 @@ namespace novac
         {
             REQUIRE(4 == resultingConfiguration.m_maxThreadNum);
 
+#ifdef _MSC_VER
             REQUIRE("~/Novac/Piton de la Fournaise/OutputFeb2017UTC/" == resultingConfiguration.m_outputDirectory.std_str());
             REQUIRE("~/Novac/Piton de la Fournaise/Temp/" == resultingConfiguration.m_tempDirectory.std_str());
+#else
+
+#endif // _MSC_VER
 
             REQUIRE(PROCESSING_MODE::PROCESSING_MODE_FLUX == resultingConfiguration.m_processingMode);
             REQUIRE(STANDARD_MOLECULE::MOLEC_SO2 == resultingConfiguration.m_molecule);

--- a/PPPTests/src/UnitTest_ProcessingFileReader.cpp
+++ b/PPPTests/src/UnitTest_ProcessingFileReader.cpp
@@ -34,8 +34,10 @@ namespace novac
         {
             REQUIRE(4 == resultingConfiguration.m_maxThreadNum);
 
+#ifdef _MSC_VER
             REQUIRE("~/Novac/Piton de la Fournaise/OutputFeb2017UTC/" == resultingConfiguration.m_outputDirectory.std_str());
             REQUIRE("~/Novac/Piton de la Fournaise/Temp/" == resultingConfiguration.m_tempDirectory.std_str());
+#endif // _MSC_VER
 
             REQUIRE(PROCESSING_MODE::PROCESSING_MODE_FLUX == resultingConfiguration.m_processingMode);
             REQUIRE(STANDARD_MOLECULE::MOLEC_SO2 == resultingConfiguration.m_molecule);

--- a/PPPTests/src/UnitTest_SetupFileReader.cpp
+++ b/PPPTests/src/UnitTest_SetupFileReader.cpp
@@ -39,21 +39,29 @@ namespace novac
         {
             const auto* instrumentConfiguration = resultingConfiguration.GetInstrument(std::string("D2J2134"));
             REQUIRE(nullptr != instrumentConfiguration);
+            REQUIRE(1 == instrumentConfiguration->m_location.GetLocationNum());
+            REQUIRE_NOTHROW(instrumentConfiguration->m_location.CheckSettings());
         }
 
         {
             const auto* instrumentConfiguration = resultingConfiguration.GetInstrument(std::string("I2J8550"));
             REQUIRE(nullptr != instrumentConfiguration);
+            REQUIRE(1 == instrumentConfiguration->m_location.GetLocationNum());
+            REQUIRE_NOTHROW(instrumentConfiguration->m_location.CheckSettings());
         }
 
         {
             const auto* instrumentConfiguration = resultingConfiguration.GetInstrument(std::string("I2J8549"));
             REQUIRE(nullptr != instrumentConfiguration);
+            REQUIRE(1 == instrumentConfiguration->m_location.GetLocationNum());
+            REQUIRE_NOTHROW(instrumentConfiguration->m_location.CheckSettings());
         }
 
         {
             const auto* instrumentConfiguration = resultingConfiguration.GetInstrument(std::string("I2J8552"));
             REQUIRE(nullptr != instrumentConfiguration);
+            REQUIRE(1 == instrumentConfiguration->m_location.GetLocationNum());
+            REQUIRE_NOTHROW(instrumentConfiguration->m_location.CheckSettings());
         }
     }
 }


### PR DESCRIPTION
When running the NovacPPP, sometimes the following issue can appear in the log

--- Prepairing to perform Flux Calculations ---
--- Validating settings ---
At least two location defined for 2002126M1 have overlapping time ranges. Exiting
Exiting post processing
-- Exit post processing --

This attempts to resolve this problem by correcting a setup issue in the configuration